### PR TITLE
Update to pass marker names and metadata to/from XML

### DIFF
--- a/src/main/java/CellCntrMarkerVector.java
+++ b/src/main/java/CellCntrMarkerVector.java
@@ -41,11 +41,13 @@ import org.scijava.options.OptionsService;
 public class CellCntrMarkerVector extends Vector<CellCntrMarker> {
 
 	private int type;
+	private String name;
 
 	/** Creates a new instance of MarkerVector */
-	public CellCntrMarkerVector(final int type) {
+	public CellCntrMarkerVector(final int type, final String name) {
 		super();
 		this.type = type;
+		this.name = name;
 	}
 
 	public void addMarker(final CellCntrMarker marker) {
@@ -101,6 +103,14 @@ public class CellCntrMarkerVector extends Vector<CellCntrMarker> {
 
 	public void setType(final int type) {
 		this.type = type;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public void setName(final String name) {
+		this.name = name;
 	}
 
 	public Color getColor() {

--- a/src/main/java/ReadXML.java
+++ b/src/main/java/ReadXML.java
@@ -92,15 +92,22 @@ public class ReadXML {
 	public Vector<CellCntrMarkerVector> readMarkerData() {
 		final Vector<CellCntrMarkerVector> typeVector =
 			new Vector<CellCntrMarkerVector>();
+		String markerName = "";
 
 		final NodeList markerTypeNodeList = getNodeListFromTag(doc, "Marker_Type");
 		for (int i = 0; i < markerTypeNodeList.getLength(); i++) {
 			final Element markerTypeElement = getElement(markerTypeNodeList, i);
 			final NodeList typeNodeList =
 				markerTypeElement.getElementsByTagName("Type");
+			// Reads type name, with bypass for older format.
+			final NodeList nameNodeList = 
+				markerTypeElement.getElementsByTagName("Name");
+			markerName = ("Type " + Integer.parseInt(readValue(typeNodeList, 0)));
+			if(nameNodeList.getLength() > 0) {
+				markerName = readValue(nameNodeList, 0);
+			}
 			final CellCntrMarkerVector markerVector =
-				new CellCntrMarkerVector(Integer.parseInt(readValue(typeNodeList, 0)));
-
+					new CellCntrMarkerVector(Integer.parseInt(readValue(typeNodeList, 0)), markerName);				
 			final NodeList markerNodeList =
 				markerTypeElement.getElementsByTagName("Marker");
 			for (int j = 0; j < markerNodeList.getLength(); j++) {

--- a/src/main/java/WriteXML.java
+++ b/src/main/java/WriteXML.java
@@ -31,7 +31,10 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ListIterator;
+import java.util.Iterator;
 import java.util.Vector;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * TODO
@@ -63,7 +66,9 @@ public class WriteXML {
 	}
 
 	public boolean writeXML(final String imgFilename,
-		final Vector<CellCntrMarkerVector> typeVector, final int currentType)
+		final Vector<CellCntrMarkerVector> typeVector,
+		final int currentType,
+		final Map<String,String> metaData)
 	{
 		try {
 			out.write("<?xml version=\"1.0\" ");
@@ -72,8 +77,16 @@ public class WriteXML {
 
 			// write the image properties
 			out.write(" <Image_Properties>\r\n");
-			out
-				.write("     <Image_Filename>" + imgFilename + "</Image_Filename>\r\n");
+			out.write("     <Image_Filename>" + imgFilename + "</Image_Filename>\r\n");
+			// add further metadata to properties
+			final Set metaDataSet = metaData.entrySet();
+			final Iterator iterator = metaDataSet.iterator();
+			while(iterator.hasNext()) {
+				Map.Entry entry = (Map.Entry)iterator.next();
+				final String key = (entry.getKey()).toString();
+				final String value = (entry.getValue()).toString();
+				out.write("     <" + key + ">" + value + "</" + key + ">\r\n");
+			}
 			out.write(" </Image_Properties>\r\n");
 
 			// write the marker data
@@ -83,8 +96,10 @@ public class WriteXML {
 			while (it.hasNext()) {
 				final CellCntrMarkerVector markerVector = it.next();
 				final int type = markerVector.getType();
+				final String name = markerVector.getName();
 				out.write("     <Marker_Type>\r\n");
 				out.write("         <Type>" + type + "</Type>\r\n");
+				out.write("         <Name>" + name + "</Name>\r\n");
 				final ListIterator<CellCntrMarker> lit = markerVector.listIterator();
 				while (lit.hasNext()) {
 					final CellCntrMarker marker = lit.next();


### PR DESCRIPTION
I've updated some classes and methods to add more useful data to XML marker files, which can be handy when processing to other programs (currently working on a tool for multicellular feature detection with coexpressing markers). I've added the following:
- Marker Name attributes to CellCntrMarkerVector class.
- Marker Name reading/writing from/to XML, respectively.
     - Includes reverse compatibility for loading older marker XML format.
- Metadata map object to store attributes in a key:value format to write to Image Properties. Currently includes X/Y/Z/unit calibration data, but can be expanded to include any useful attribute.